### PR TITLE
Fix PHPDoc block and Test Classes

### DIFF
--- a/Duitku/Api.php
+++ b/Duitku/Api.php
@@ -232,7 +232,7 @@ class Api extends Request
      * }
      * 
      * @param \Duitku\Config $config
-     * @return json response
+     * @return string JSON-encoded callback data
      * @throws Exception
      */
     public static function callback($config)

--- a/Duitku/Pop.php
+++ b/Duitku/Pop.php
@@ -237,7 +237,7 @@ class Pop extends Request
 	 * }
 	 * 
 	 * @param \Duitku\Config $config
-	 * @return json response
+	 * @return string JSON-encoded callback data
 	 * @throws Exception
 	 */
 	public static function callback($config)

--- a/tests/CreateInvoiceTest.php
+++ b/tests/CreateInvoiceTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once dirname(__FILE__) . '/../Duitku.php';
 
-class TransactionStatusTest extends TestCase
+class CreateInvoiceTest extends TestCase
 {
     public function testGetJson()
     {

--- a/tests/GetPaymentMethodTest.php
+++ b/tests/GetPaymentMethodTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once dirname(__FILE__) . '/../Duitku.php';
 
-class GetPaymentMethodApiTest extends TestCase
+class GetPaymentMethodTest extends TestCase
 {
     public function testGetJson()
     {


### PR DESCRIPTION
1. **[Fix PHPDoc Block, return type on callback API and POP](https://github.com/duitkupg/duitku-php/pull/5/commits/4e0cbf63cdb4f8de6a7fca5b8bd4dfce2e65ded1)**
https://github.com/duitkupg/duitku-php/issues/4

=> from this **[Issue 4](https://github.com/duitkupg/duitku-php/issues/4)**, show that on Documentation PHPDoc [API Callback](https://github.com/duitkupg/duitku-php/blob/master/Duitku/Api.php) and [POP Callback](https://github.com/duitkupg/duitku-php/blob/master/Duitku/Pop.php) is giving return type json, that was not a valid type on PHP. The actual type returned by the function is string (by json_encoded) that need to be json_decoded after

![image](https://github.com/user-attachments/assets/259e62de-9106-4c04-82a6-29689933dfbb)
![image](https://github.com/user-attachments/assets/bce42daf-c582-4e3d-bb50-d6d4ce18d0f0)

although it didnt have impact when using the function, but it showing error on IDE or analysis tools (intelephense). By this commit it changed the PHPDoc to be  `* @return string JSON-encoded callback data`

2. **[Fix Test naming Classess](https://github.com/duitkupg/duitku-php/pull/5/commits/df239a1b95a84f9e663ff2f2c5d39352cfe7ccef)**

=> when trying to check test cases using the provided tests function, it show error on **CreateInvoiceTest.php**, and **GetPaymentMethodTest.php**, because of it naming tests classes doesnt valid with it file name, by this commit, fix the naming testsclasses